### PR TITLE
feat(markdownbuilder): create an option to skip any property in markdown

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -184,7 +184,6 @@ async function main(args) {
         ).split(npath.sep).join(npath.posix.sep);
         return target;
       },
-      exampleformat: argv.f,
     }),
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -99,7 +99,12 @@ async function main(args) {
     .alias('h', 'header')
     .boolean('h')
     .describe('h', 'if the value is false the header will be skipped')
-    .default('h', true);
+    .default('h', true)
+
+    .alias('s', 'skip')
+    .array('s')
+    .describe('s', 'name of a default property to skip in markdown (may be used multiple times), e.g. -s typefact -s proptable')
+    .default('s', []);
 
   const docs = pipe(
     iter(argv),
@@ -167,7 +172,7 @@ async function main(args) {
       header: argv.h,
       links: docs,
       includeproperties: argv.p,
-      exampleformat: argv.f,
+      skipproperties: argv.s,
       rewritelinks: (origin) => {
         const mddir = argv.o;
         const srcdir = argv.d;
@@ -179,6 +184,7 @@ async function main(args) {
         ).split(npath.sep).join(npath.posix.sep);
         return target;
       },
+      exampleformat: argv.f,
     }),
 
 

--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -327,7 +327,7 @@ function build({
    */
   function makeproptable(props = {}, patternProps = {}, additionalProps, required, slugger) {
     if (skipproperties.includes('proptable')) {
-      return table();
+      return paragraph();
     }
     const proprows = Object
       .entries(props)

--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -30,6 +30,7 @@ function build({
   includeproperties = [],
   rewritelinks = x => x,
   exampleformat = 'json',
+  skipproperties = [],
 } = {}) {
   const formats = {
     'date-time': {
@@ -325,6 +326,9 @@ function build({
    * @param {*} props
    */
   function makeproptable(props = {}, patternProps = {}, additionalProps, required, slugger) {
+    if (skipproperties.proptable) {
+      return '';
+    }
     const proprows = Object
       .entries(props)
       .map(makepropheader(required, false, slugger));
@@ -362,6 +366,9 @@ function build({
   }
 
   function makearrayfact(items, additional) {
+    if (skipproperties.arrayfact) {
+      return '';
+    }
     return listItem([
       paragraph([text(i18n`Type: `), text(i18n`an array where each item follows the corresponding schema in the following list:`)]),
       list('ordered',
@@ -387,6 +394,9 @@ function build({
   }
 
   function maketypefact(definition, isarray = '') {
+    if (skipproperties.typefact) {
+      return '';
+    }
     const alltypes = Array.isArray(definition[keyword`type`]) ? definition[keyword`type`] : [definition[keyword`type`]];
     // filter out types that are null
     const realtypes = alltypes.filter(mytype => mytype !== keyword`null`);
@@ -435,6 +445,9 @@ function build({
   }
 
   function makenullablefact(definition) {
+    if (skipproperties.nullablefact) {
+      return '';
+    }
     const alltypes = Array.isArray(definition[keyword`type`]) ? definition[keyword`type`] : [definition[keyword`type`]];
     // can the type be `null`
     const isnullable = alltypes.filter(mytype => mytype === keyword`null`).length > 0;
@@ -447,6 +460,9 @@ function build({
   }
 
   function makedefinedinfact(definition) {
+    if (skipproperties.definedinfact) {
+      return '';
+    }
     return listItem(paragraph([
       text(i18n`defined in: `),
       link(`${definition[s.slug]}.md`, `${definition[s.id]}#${definition[s.pointer]}`, text(definition[s.titles] && definition[s.titles][0] ? definition[s.titles][0] : i18n`Untitled schema`)),
@@ -524,6 +540,9 @@ function build({
   }
 
   function maketypesection(schema, level = 1) {
+    if (!skipproperties.typesection) {
+      return '';
+    }
     const { children } = maketypefact(schema);
     children[0].children.shift();
     return [

--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -326,8 +326,8 @@ function build({
    * @param {*} props
    */
   function makeproptable(props = {}, patternProps = {}, additionalProps, required, slugger) {
-    if (skipproperties.proptable) {
-      return '';
+    if (skipproperties.includes('proptable')) {
+      return table();
     }
     const proprows = Object
       .entries(props)
@@ -366,7 +366,7 @@ function build({
   }
 
   function makearrayfact(items, additional) {
-    if (skipproperties.arrayfact) {
+    if (skipproperties.includes('arrayfact')) {
       return '';
     }
     return listItem([
@@ -394,9 +394,6 @@ function build({
   }
 
   function maketypefact(definition, isarray = '') {
-    if (skipproperties.typefact) {
-      return '';
-    }
     const alltypes = Array.isArray(definition[keyword`type`]) ? definition[keyword`type`] : [definition[keyword`type`]];
     // filter out types that are null
     const realtypes = alltypes.filter(mytype => mytype !== keyword`null`);
@@ -445,9 +442,6 @@ function build({
   }
 
   function makenullablefact(definition) {
-    if (skipproperties.nullablefact) {
-      return '';
-    }
     const alltypes = Array.isArray(definition[keyword`type`]) ? definition[keyword`type`] : [definition[keyword`type`]];
     // can the type be `null`
     const isnullable = alltypes.filter(mytype => mytype === keyword`null`).length > 0;
@@ -460,9 +454,6 @@ function build({
   }
 
   function makedefinedinfact(definition) {
-    if (skipproperties.definedinfact) {
-      return '';
-    }
     return listItem(paragraph([
       text(i18n`defined in: `),
       link(`${definition[s.slug]}.md`, `${definition[s.id]}#${definition[s.pointer]}`, text(definition[s.titles] && definition[s.titles][0] ? definition[s.titles][0] : i18n`Untitled schema`)),
@@ -479,9 +470,15 @@ function build({
       children.push(listItem(text(i18n`is optional`)));
     }
 
-    children.push(maketypefact(definition));
-    children.push(makenullablefact(definition));
-    children.push(makedefinedinfact(definition));
+    if (!skipproperties.includes('typefact')) {
+      children.push(maketypefact(definition));
+    }
+    if (!skipproperties.includes('nullablefact')) {
+      children.push(makenullablefact(definition));
+    }
+    if (!skipproperties.includes('definedinfact')) {
+      children.push(makedefinedinfact(definition));
+    }
 
     const additionalfacts = includeproperties.map((propname) => {
       if (definition[propname]) {
@@ -540,7 +537,7 @@ function build({
   }
 
   function maketypesection(schema, level = 1) {
-    if (!skipproperties.typesection) {
+    if (skipproperties.includes('typesection')) {
       return '';
     }
     const { children } = maketypefact(schema);

--- a/test/fixtures/skipproperties/complete.schema.json
+++ b/test/fixtures/skipproperties/complete.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Complete JSON Schema",
+  "description": "Testing for skipped props",
+  "type": "object",
+  "properties": {
+      "foo": {
+          "type": "string"
+      },
+      "bar": {
+          "description": "Configures the bar property",
+          "type": "boolean",
+          "default": "true"
+      },
+      "foobar": {
+          "description": "Overwrite the bar value",
+          "examples":[{
+            "bar": "true",
+            "foobar": "no"
+          }],
+          "type": "string",
+          "format": "yes/no"
+      }
+    },
+    "additionalProperties": false,
+    "required": [
+        "bar"
+    ]
+}

--- a/test/markdownBuilder.test.js
+++ b/test/markdownBuilder.test.js
@@ -404,37 +404,29 @@ Reference this group by using
 });
 
 describe('Testing Markdown Builder: Skip properties', () => {
-  let results;
+  let schemas;
 
   before(async () => {
-    const schemas = await loadschemas('readme-1');
-    const builder = build({ header: true, links: { abstract: 'fooabstract.html' }, skipproperties: ['typesection', 'definedinfact'] });
-    results = builder(schemas);
+    schemas = await loadschemas('skipproperties');
+  });
+
+  it('Skipped properties exist', () => {
+    const builder = build({});
+    const results = builder(schemas);
+
+    assertMarkdown(results.complete)
+      .contains('### bar Type')
+      .contains('| Property          | Type      | Required |')
+      .contains('-   defined in: [Complete JSON Schema]');
   });
 
   it('Skips the expected properties', () => {
-    assertMarkdown(results.abstract)
-      .equals('heading > text', { type: 'text', value: 'Abstract Schema' })
-      .contains('cannot be read or written')
-      .contains('nonfoo Access Restrictions')
-      .contains('bar Access Restrictions')
-      .contains('### foo Access Restrictions')
-      .fuzzy`
-## Definitions group second
+    const builder = build({ skipproperties: ['typesection', 'definedinfact', 'proptable'] });
+    const results = builder(schemas);
 
-Reference this group by using
-
-\`\`\`json
-{"$ref":"https://example.com/schemas/abstract#/$defs/second"}
-\`\`\``
-      .fuzzy`
-\`bar\`
-
--   is optional
--   Type: \`string\`
--   cannot be null`
-      .contains('fooabstract.html');
-    //      .inspect()
-    //      .print();
+    assertMarkdown(results.complete)
+      .doesNotContain('### bar Type')
+      .doesNotContain('| Property          | Type      | Required |')
+      .doesNotContain('-   defined in: [Complete JSON Schema]');
   });
 });

--- a/test/markdownBuilder.test.js
+++ b/test/markdownBuilder.test.js
@@ -402,3 +402,39 @@ Reference this group by using
       .contains('# Simple Schema');
   });
 });
+
+describe('Testing Markdown Builder: Skip properties', () => {
+  let results;
+
+  before(async () => {
+    const schemas = await loadschemas('readme-1');
+    const builder = build({ header: true, links: { abstract: 'fooabstract.html' }, skipproperties: ['typesection', 'definedinfact'] });
+    results = builder(schemas);
+  });
+
+  it('Skips the expected properties', () => {
+    assertMarkdown(results.abstract)
+      .equals('heading > text', { type: 'text', value: 'Abstract Schema' })
+      .contains('cannot be read or written')
+      .contains('nonfoo Access Restrictions')
+      .contains('bar Access Restrictions')
+      .contains('### foo Access Restrictions')
+      .fuzzy`
+## Definitions group second
+
+Reference this group by using
+
+\`\`\`json
+{"$ref":"https://example.com/schemas/abstract#/$defs/second"}
+\`\`\``
+      .fuzzy`
+\`bar\`
+
+-   is optional
+-   Type: \`string\`
+-   cannot be null`
+      .contains('fooabstract.html');
+    //      .inspect()
+    //      .print();
+  });
+});

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -29,6 +29,11 @@ function assertMarkdown(node) {
 ${result}`);
       return tester;
     };
+    tester.doesNotContain = (str) => {
+      assert.ok(result.indexOf(str) < 0, `Markdown output contains search string "${str}"
+${result}`);
+      return tester;
+    };
     tester.matches = (re) => {
       assert.ok(result.match(re), `Markdown output does not match regex "${String(re)}"
 ${result}`);


### PR DESCRIPTION
Creating the `s`, `skip` option, to be able to choose what goes in the markdown output.